### PR TITLE
Removing a useless use of grep

### DIFF
--- a/start
+++ b/start
@@ -15,7 +15,7 @@ cmd-run() {
 		run_mode="-join $join_ip"
 	fi
 
-	bridge_ip="$(ip ro | grep ^default | awk '{print $3}')"
+	bridge_ip="$(ip ro | awk '/^default/{print $3}')"
 	cat <<EOF
 eval docker run --name consul -h \$HOSTNAME \
 	-p $external_ip:8300:8300 \


### PR DESCRIPTION
awk can do the same for simple invocations of grep using Posix regular expressions.
