### PR TITLE
Fix #7 SIGINT cannot stop process issue

### DIFF
--- a/start
+++ b/start
@@ -35,7 +35,7 @@ main() {
 	set -eo pipefail
 	case "$1" in
 	cmd:run)            shift; cmd-run $@;;
-	*)                  /bin/consul agent -config-dir=/config $@;;
+	*)                  exec /bin/consul agent -config-dir=/config $@;;
 	esac
 }
 


### PR DESCRIPTION
Fix #7

This works, the idea is to use `exec` to let consul process replace the bash, so that it can response to SIGINT directly. However, not sure is there any side effect by doing this.
