### PR TITLE
Add 'dist' directory for webui

### DIFF
--- a/0.6/consul-server/Dockerfile
+++ b/0.6/consul-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM gliderlabs/consul-agent:0.6
 ADD ./config /config/
 ADD https://releases.hashicorp.com/consul/0.6.0/consul_0.6.0_web_ui.zip /tmp/webui.zip
-RUN cd /tmp && unzip webui.zip && mv dist /ui && rm webui.zip
+RUN cd /tmp && mkdir dist && unzip webui.zip -d dist && mv dist /ui && rm webui.zip
 ENTRYPOINT ["/bin/consul", "agent", "-server", "-config-dir=/config"]


### PR DESCRIPTION
`consul_0.6.0_web_ui.zip` is not wrapped by `dist` directory.

```
$ wget https://releases.hashicorp.com/consul/0.6.0/consul_0.6.0_web_ui.zip -O webui.zip
$ unzip webui.zip
Archive:  webui.zip
  inflating: index.html
   creating: static/
  inflating: static/application.min.js
  inflating: static/base.css
  inflating: static/base.css.map
  inflating: static/bootstrap.min.css
  inflating: static/consul-logo.png
  inflating: static/favicon.png
  inflating: static/loading-cylon-purple.svg
```

so I got error
```
unzip: can't change directory to 'dist': No such file or directory
```

This PR is adding `mkdir dist` before `unzip`.