### PR TITLE
moving UI support to build in consul UI

### DIFF
--- a/0.6/consul-server/Dockerfile
+++ b/0.6/consul-server/Dockerfile
@@ -1,5 +1,3 @@
 FROM gliderlabs/consul-agent:0.6
 ADD ./config /config/
-ADD https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_web_ui.zip /tmp/webui.zip
-RUN cd /tmp && mkdir /ui && unzip webui.zip -d /ui && rm webui.zip
 ENTRYPOINT ["/bin/consul", "agent", "-server", "-config-dir=/config"]

--- a/0.6/consul-server/config/server.json
+++ b/0.6/consul-server/config/server.json
@@ -1,6 +1,5 @@
 {
-	"ui_dir": "/ui",
-	"server": true,
+	"ui": true,
 	"dns_config": {
 		"allow_stale": false
 	}


### PR DESCRIPTION
I removed the UI download and added the flag for -ui

I noticed -ui and -server are specified on the command line and the config.  These are duplicate settings would it make sense to remove them from the config and just specify them on the command line or vice versa?