### PR TITLE
Added Dockerfile Labels from label-schema.org

### DIFF
--- a/0.6/consul/Dockerfile
+++ b/0.6/consul/Dockerfile
@@ -4,6 +4,17 @@ ENV CONSUL_VERSION 0.6.4
 ENV CONSUL_SHA256 abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf0627
 ENV GLIBC_VERSION "2.23-r1"
 
+# Basic build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.license="BSD" \
+      org.label-schema.name="Consul Agent in Docker" \
+      org.label-schema.url="https://hub.docker.com/r/progrium/consul/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/gliderlabs/docker-consul.git" \
+      org.label-schema.vcs-type="Git"
+
 RUN apk --update add curl ca-certificates && \
     curl -Ls https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk > /tmp/glibc-${GLIBC_VERSION}.apk && \
     apk add --allow-untrusted /tmp/glibc-${GLIBC_VERSION}.apk && \

--- a/0.6/consul/Makefile
+++ b/0.6/consul/Makefile
@@ -1,3 +1,5 @@
 
 build:
-	docker build -t gliderlabs/consul:$(VERSION) .
+	docker build -t gliderlabs/consul:$(VERSION) \
+							 --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+							 --build-arg VCS_REF=`git rev-parse --short HEAD` .


### PR DESCRIPTION
Hey Jeff, I'm working with some folks in the container community on a standard label schema. To get momentum we want to encourage as many people as possible to label their public container images.

To make it as easy as possible for you, here's a PR that will label your image automatically as part of your existing build process.

Once the labels are in place you could use MicroBadger (microbadger.com) to create image badges for jumping between your Docker Image and the appropriate commit on Github.

And if you're interested in getting involved with the label standardization, please jump on in at label-schema.org.