### PR TITLE
Put back curl and ca-certificates in the image

### DIFF
--- a/0.6/consul/Dockerfile
+++ b/0.6/consul/Dockerfile
@@ -10,7 +10,6 @@ RUN apk --no-cache add curl ca-certificates \
     && cd /bin \
     && unzip /tmp/consul.zip \
     && chmod +x /bin/consul \
-    && rm /tmp/consul.zip \
-    && apk del curl ca-certificates
+    && rm /tmp/consul.zip
 
 ENTRYPOINT ["/bin/consul"]


### PR DESCRIPTION
Don't delete curl and ca-certificates, it is needed for consul script healthcheck.